### PR TITLE
Fix registration rewrite, migration handling, and proxy scheme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN if [ -f config/jetstream.php ]; then \
   php -r '$f=\"config/jetstream.php\";$s=file_get_contents($f);if(strpos($s,\"Features::registration()\")===false){$s=preg_replace(\"/(\\'features\\'\\s*=>\\s*\\[)/\",\"$1\\n        Laravel\\\\Jetstream\\\\Features::registration(),\",$s,1);} file_put_contents($f,$s);'; \
 fi
 RUN if [ -f routes/web.php ]; then \
-  sed -i "s/Auth::routes(\\([^)]*register[^)]*\\)false/ Auth::routes(\\1true/g" routes/web.php || true; \
+  php -r '$f="routes/web.php"; $s=file_get_contents($f); $s=preg_replace("/Auth::routes\\(([^;]*'"'"'register'"'"'\\s*=>\\s*)false/", "Auth::routes($1true", $s, -1, $c); if ($c) file_put_contents($f, $s);'; \
 fi
 
 # --- SIGN-UP OVERRIDE: copy file and require it at end of routes/web.php ---

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if ! grep -q "^APP_KEY=base64:" .env || grep -q "^APP_KEY=\s*$" .env; then
 fi
 
 # Idempotent migrations
-php artisan migrate --force || true
+php artisan migrate --force
 
 exec "$@"
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,8 +18,8 @@ server {
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_param PATH_INFO $fastcgi_path_info;
     fastcgi_read_timeout 300;
-    fastcgi_param HTTPS off;
-    fastcgi_param HTTP_X_FORWARDED_PROTO http;
+    fastcgi_param HTTPS $https if_not_empty;
+    fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
     fastcgi_pass app:9000;
   }
 


### PR DESCRIPTION
## Summary
- fix the build-time registration toggle so it replaces `register => false` without introducing a syntax error
- allow entrypoint migrations to fail loudly once the database check has succeeded
- forward the request scheme/HTTPS flag from nginx instead of forcing `http`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb15c0d0f4832ebfebeadeab3d3d85