### PR TITLE
Add email template management and settings guidance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,13 @@ fi
 COPY routes/_sign_up_override.php /var/www/html/routes/_sign_up_override.php
 RUN printf "\n// Allow public sign up without redirecting to /login\nrequire __DIR__.'/_sign_up_override.php';\n" >> routes/web.php
 
+# Overlay project-specific customizations
+COPY overlay/ /var/www/html/
+COPY scripts/customize_email_templates.php /tmp/customize_email_templates.php
+RUN php /tmp/customize_email_templates.php /var/www/html
+
 # Skip settings bootstrap when no DB is available (eg. during image build)
+
 RUN php <<'PHP'
 <?php
 $dir = __DIR__ . '/app/Providers';

--- a/overlay/app/Http/Controllers/EmailTemplateController.php
+++ b/overlay/app/Http/Controllers/EmailTemplateController.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class EmailTemplateController extends Controller
+{
+    /**
+     * Get the base path for Blade templates.
+     */
+    protected function viewsBasePath(): string
+    {
+        return resource_path('views');
+    }
+
+    /**
+     * Directories that may contain email templates.
+     *
+     * @return array<int, string>
+     */
+    protected function templateDirectories(): array
+    {
+        $base = $this->viewsBasePath();
+
+        $candidates = [
+            $base . DIRECTORY_SEPARATOR . 'emails',
+            $base . DIRECTORY_SEPARATOR . 'mail',
+            $base . DIRECTORY_SEPARATOR . 'email',
+            $base . DIRECTORY_SEPARATOR . 'mailers',
+        ];
+
+        return array_values(array_filter($candidates, static fn (string $path) => is_dir($path)));
+    }
+
+    /**
+     * List all discoverable template files.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function discoverTemplates(): array
+    {
+        $templates = [];
+        $base = realpath($this->viewsBasePath());
+
+        if ($base === false) {
+            return $templates;
+        }
+
+        foreach ($this->templateDirectories() as $directory) {
+            foreach (File::allFiles($directory) as $file) {
+                $filename = $file->getFilename();
+
+                if (!str_ends_with($filename, '.blade.php')) {
+                    continue;
+                }
+
+                $relative = Str::after($file->getPathname(), $base . DIRECTORY_SEPARATOR);
+                $templates[] = [
+                    'key' => $this->encodeKey($relative),
+                    'relative' => str_replace(DIRECTORY_SEPARATOR, '/', $relative),
+                    'label' => Str::headline(Str::before($filename, '.blade.php')),
+                ];
+            }
+        }
+
+        usort($templates, static fn ($a, $b) => strcmp($a['label'], $b['label']));
+
+        return $templates;
+    }
+
+    /**
+     * Encode a relative template path into a URL-safe key.
+     */
+    protected function encodeKey(string $relativePath): string
+    {
+        $relativePath = str_replace('\\', '/', $relativePath);
+        $encoded = base64_encode($relativePath);
+        return rtrim(strtr($encoded, '+/', '-_'), '=');
+    }
+
+    /**
+     * Decode a key back into a relative path.
+     */
+    protected function decodeKey(string $key): ?string
+    {
+        $key = str_replace(['-', '_'], ['+', '/'], $key);
+        $padding = strlen($key) % 4;
+        if ($padding) {
+            $key .= str_repeat('=', 4 - $padding);
+        }
+
+        $decoded = base64_decode($key, true);
+
+        if ($decoded === false) {
+            return null;
+        }
+
+        $decoded = str_replace('\\', '/', $decoded);
+
+        if (str_contains($decoded, '..')) {
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Resolve a template key into its absolute path and relative label.
+     *
+     * @return array{relative: string, path: string}
+     */
+    protected function resolveTemplate(string $key): array
+    {
+        $relative = $this->decodeKey($key);
+        if ($relative === null) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
+
+        $base = realpath($this->viewsBasePath());
+        if ($base === false) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
+
+        $absolute = realpath($base . DIRECTORY_SEPARATOR . $relative);
+        if ($absolute === false || !is_file($absolute)) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
+
+        if (!str_starts_with($absolute, $base)) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
+
+        return [
+            'relative' => str_replace(DIRECTORY_SEPARATOR, '/', $relative),
+            'path' => $absolute,
+        ];
+    }
+
+    public function index(Request $request)
+    {
+        $this->authorizeSettings($request);
+
+        return view('settings.email-templates.index', [
+            'templates' => $this->discoverTemplates(),
+        ]);
+    }
+
+    public function edit(Request $request, string $template)
+    {
+        $this->authorizeSettings($request);
+
+        $resolved = $this->resolveTemplate($template);
+
+        return view('settings.email-templates.edit', [
+            'templateKey' => $template,
+            'templateRelativePath' => $resolved['relative'],
+            'contents' => File::get($resolved['path']),
+        ]);
+    }
+
+    public function update(Request $request, string $template)
+    {
+        $this->authorizeSettings($request);
+
+        $resolved = $this->resolveTemplate($template);
+
+        $data = $request->validate([
+            'contents' => ['required', 'string'],
+        ]);
+
+        File::put($resolved['path'], $data['contents']);
+
+        return redirect()
+            ->route('settings.email-templates.edit', ['template' => $template])
+            ->with('status', 'Email template updated successfully.');
+    }
+
+    protected function authorizeSettings(Request $request): void
+    {
+        $user = $request->user();
+
+        if ($user === null) {
+            abort(Response::HTTP_FORBIDDEN);
+        }
+
+        if (method_exists($user, 'can') && $user->can('manage-settings')) {
+            return;
+        }
+
+        if (method_exists($user, 'isAdmin') && $user->isAdmin()) {
+            return;
+        }
+
+        if (method_exists($user, 'hasRole') && $user->hasRole('admin')) {
+            return;
+        }
+
+        abort(Response::HTTP_FORBIDDEN);
+    }
+}

--- a/overlay/resources/views/settings/email-templates/edit.blade.php
+++ b/overlay/resources/views/settings/email-templates/edit.blade.php
@@ -1,0 +1,64 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-sm text-gray-500">{{ __('Editing email template') }}</p>
+                <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                    {{ $templateRelativePath }}
+                </h2>
+            </div>
+            <a href="{{ route('settings.email-templates.index') }}" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                {{ __('Back to list') }}
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-10">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white shadow-xl sm:rounded-lg">
+                <div class="px-4 py-5 sm:p-6 space-y-6">
+                    @if (session('status'))
+                        <div class="rounded-md bg-green-50 p-4">
+                            <div class="flex">
+                                <div class="flex-shrink-0">
+                                    <svg class="h-5 w-5 text-green-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 10-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.14-.094l4-5.5z" clip-rule="evenodd" />
+                                    </svg>
+                                </div>
+                                <div class="ml-3">
+                                    <p class="text-sm font-medium text-green-800">{{ session('status') }}</p>
+                                </div>
+                            </div>
+                        </div>
+                    @endif
+
+                    <form method="POST" action="{{ route('settings.email-templates.update', ['template' => $templateKey]) }}" class="space-y-6">
+                        @csrf
+                        @method('PUT')
+
+                        <div>
+                            <label for="contents" class="block text-sm font-medium text-gray-700">
+                                {{ __('Template contents') }}
+                            </label>
+                            <div class="mt-1">
+                                <textarea id="contents" name="contents" rows="20" class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border border-gray-300 rounded-md font-mono">{{ old('contents', $contents) }}</textarea>
+                            </div>
+                            <p class="mt-2 text-sm text-gray-500">
+                                {{ __('Blade syntax is supported. Variables will be available exactly as they are when the email is rendered by EventSchedule.') }}
+                            </p>
+                            @error('contents')
+                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <div class="flex justify-end">
+                            <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                {{ __('Save changes') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/overlay/resources/views/settings/email-templates/index.blade.php
+++ b/overlay/resources/views/settings/email-templates/index.blade.php
@@ -1,0 +1,59 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Email Templates') }}
+            </h2>
+            @php
+                $settingsRoute = Route::has('settings.index') ? route('settings.index') : url('/');
+            @endphp
+            <a href="{{ $settingsRoute }}" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                {{ __('Back to Settings') }}
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-10">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
+                <div class="px-4 py-5 sm:p-6">
+                    <p class="text-sm text-gray-600">
+                        {{ __('Review the available email templates and click edit to update the Blade markup used when EventSchedule sends each message.') }}
+                    </p>
+
+                    <div class="mt-6 border-t border-gray-200"></div>
+
+                    <div class="mt-6">
+                        <ul role="list" class="divide-y divide-gray-200">
+                            @forelse ($templates as $template)
+                                <li class="py-4">
+                                    <div class="flex items-center justify-between">
+                                        <div>
+                                            <p class="text-sm font-medium text-gray-900">
+                                                {{ $template['label'] }}
+                                            </p>
+                                            <p class="text-sm text-gray-500">
+                                                {{ $template['relative'] }}
+                                            </p>
+                                        </div>
+                                        <div class="flex space-x-3">
+                                            <a href="{{ route('settings.email-templates.edit', ['template' => $template['key']]) }}" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                                {{ __('Edit') }}
+                                            </a>
+                                        </div>
+                                    </div>
+                                </li>
+                            @empty
+                                <li class="py-4">
+                                    <p class="text-sm text-gray-500">
+                                        {{ __('No email templates were found in the expected directories.') }}
+                                    </p>
+                                </li>
+                            @endforelse
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/scripts/customize_email_templates.php
+++ b/scripts/customize_email_templates.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+$base = $argv[1] ?? getcwd();
+$base = rtrim($base, "/");
+
+$webPath = $base . '/routes/web.php';
+if (is_file($webPath)) {
+    $code = file_get_contents($webPath);
+    $useStatement = "use App\\Http\\Controllers\\EmailTemplateController;";
+
+    if (strpos($code, $useStatement) === false) {
+        if (preg_match_all('/^use\s+[^;]+;/m', $code, $matches, PREG_OFFSET_CAPTURE)) {
+            $last = end($matches[0]);
+            if ($last) {
+                $insertPos = $last[1] + strlen($last[0]);
+                $code = substr_replace($code, "\n" . $useStatement, $insertPos, 0);
+            }
+        } else {
+            $phpPos = strpos($code, '<?php');
+            if ($phpPos !== false) {
+                $insertPos = $phpPos + strlen('<?php');
+                $code = substr_replace($code, "\n\n" . $useStatement, $insertPos, 0);
+            } else {
+                $code = "<?php\n\n" . $useStatement . "\n" . ltrim($code);
+            }
+        }
+    }
+
+    if (strpos($code, 'EmailTemplateController::class') === false) {
+        $snippetLines = [
+            "",
+            "Route::middleware(['auth'])->prefix('settings')->name('settings.')->group(function () {",
+            "    Route::get('email-templates', [EmailTemplateController::class, 'index'])->name('email-templates.index');",
+            "    Route::get('email-templates/{template}/edit', [EmailTemplateController::class, 'edit'])->name('email-templates.edit');",
+            "    Route::put('email-templates/{template}', [EmailTemplateController::class, 'update'])->name('email-templates.update');",
+            "});",
+        ];
+
+        $code = rtrim($code) . "\n" . implode("\n", $snippetLines) . "\n";
+    }
+
+    file_put_contents($webPath, $code);
+}
+
+$settingsPaths = [
+    $base . '/resources/views/settings/index.blade.php',
+    $base . '/resources/views/settings.blade.php',
+];
+
+$noteBlock = <<<'NOTE'
+    <div class="mt-8 bg-yellow-50 border-l-4 border-yellow-400 p-4 rounded-md settings-mail-warning">
+        <div class="flex">
+            <div class="flex-shrink-0">
+                <svg class="h-5 w-5 text-yellow-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l6.451 11.48C18.944 15.943 18.094 17 16.823 17H3.177c-1.27 0-2.121-1.057-1.371-2.421l6.451-11.48zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-.25-5.75a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z" clip-rule="evenodd" />
+                </svg>
+            </div>
+            <div class="ml-3 text-sm text-yellow-800 space-y-2">
+                <p>{{ __('If you use Gmail for outbound mail you must create an app password in your Google Account and paste it here instead of your normal login password.') }}</p>
+                <p>{{ __('Google blocks standard passwords for SMTP connections, so EventSchedule will only connect successfully with an app-specific password.') }}</p>
+                @if (Route::has('settings.email-templates.index'))
+                    <p>
+                        <a href="{{ route('settings.email-templates.index') }}" class="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-yellow-900 bg-yellow-100 hover:bg-yellow-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500">
+                            {{ __('Manage email templates') }}
+                        </a>
+                    </p>
+                @endif
+            </div>
+        </div>
+    </div>
+NOTE;
+
+$removalPatterns = [
+    '/<[^>]*id="build-info"[^>]*>.*?<\\/[^>]+>\s*/is',
+    '/<section[^>]*build[^>]*>.*?<\\/section>\s*/is',
+    '/<div[^>]*>\s*<h[1-6][^>]*>[^<]*Build[^<]*<\\/h[1-6]>.*?<\\/div>\s*/is',
+];
+
+foreach ($settingsPaths as $settingsPath) {
+    if (!is_file($settingsPath)) {
+        continue;
+    }
+
+    $contents = file_get_contents($settingsPath);
+
+    foreach ($removalPatterns as $pattern) {
+        $contents = preg_replace($pattern, "\n", $contents, 1, $count);
+        if ($count) {
+            break;
+        }
+    }
+
+    if (strpos($contents, 'settings-mail-warning') === false) {
+        $insertion = "\n" . $noteBlock . "\n";
+        $pos = strripos($contents, '</x-app-layout>');
+        if ($pos === false) {
+            $pos = strripos($contents, '@endsection');
+        }
+
+        if ($pos === false) {
+            $contents .= $insertion;
+        } else {
+            $contents = substr_replace($contents, $insertion, $pos, 0);
+        }
+    }
+
+    file_put_contents($settingsPath, $contents);
+}


### PR DESCRIPTION
## Summary
- copy new email template controller and views into the container image so users can browse and edit mail templates from the UI
- add a build-time customization script that wires up the routes, removes the old build info panel, and explains Gmail app password requirements on the settings page
- ensure the Docker build copies the overlay and executes the customization script after cloning the upstream app

## Testing
- php -l overlay/app/Http/Controllers/EmailTemplateController.php
- php -l scripts/customize_email_templates.php

------
https://chatgpt.com/codex/tasks/task_e_68cb6fb8cd48832e83319b143ebef914