### PR TITLE
Add UI for editing email templates

### DIFF
--- a/overlay/resources/views/settings/email-templates/edit.blade.php
+++ b/overlay/resources/views/settings/email-templates/edit.blade.php
@@ -1,28 +1,26 @@
 <x-app-layout>
     <x-slot name="header">
-        <div class="flex items-center justify-between">
-            <div>
-                <p class="text-sm text-gray-500">{{ __('Editing email template') }}</p>
-                <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-                    {{ $templateRelativePath }}
-                </h2>
-            </div>
-            <a href="{{ route('settings.email-templates.index') }}" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                {{ __('Back to list') }}
-            </a>
-        </div>
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Email Template') }}
+        </h2>
     </x-slot>
 
-    <div class="py-10">
+    <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white shadow-xl sm:rounded-lg">
-                <div class="px-4 py-5 sm:p-6 space-y-6">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-6">
+                    <div>
+                        <p class="text-sm text-gray-600">
+                            {{ __('You are editing the :template template.', ['template' => $templateRelativePath]) }}
+                        </p>
+                    </div>
+
                     @if (session('status'))
                         <div class="rounded-md bg-green-50 p-4">
                             <div class="flex">
                                 <div class="flex-shrink-0">
                                     <svg class="h-5 w-5 text-green-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 10-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.14-.094l4-5.5z" clip-rule="evenodd" />
+                                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.114-1.006L9 11.132 7.257 9.39a.75.75 0 10-1.114 1.006l2.25 2.5a.75.75 0 001.114 0l4.25-4.705z" clip-rule="evenodd" />
                                     </svg>
                                 </div>
                                 <div class="ml-3">
@@ -32,7 +30,7 @@
                         </div>
                     @endif
 
-                    <form method="POST" action="{{ route('settings.email-templates.update', ['template' => $templateKey]) }}" class="space-y-6">
+                    <form method="POST" action="{{ route('settings.email-templates.update', ['template' => $templateKey]) }}">
                         @csrf
                         @method('PUT')
 
@@ -43,15 +41,15 @@
                             <div class="mt-1">
                                 <textarea id="contents" name="contents" rows="20" class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border border-gray-300 rounded-md font-mono">{{ old('contents', $contents) }}</textarea>
                             </div>
-                            <p class="mt-2 text-sm text-gray-500">
-                                {{ __('Blade syntax is supported. Variables will be available exactly as they are when the email is rendered by EventSchedule.') }}
-                            </p>
                             @error('contents')
                                 <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                             @enderror
                         </div>
 
-                        <div class="flex justify-end">
+                        <div class="flex items-center justify-end space-x-3">
+                            <a href="{{ route('settings.email-templates.index') }}" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-gray-700 bg-gray-100 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-300">
+                                {{ __('Cancel') }}
+                            </a>
                             <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                                 {{ __('Save changes') }}
                             </button>

--- a/overlay/resources/views/settings/email-templates/index.blade.php
+++ b/overlay/resources/views/settings/email-templates/index.blade.php
@@ -7,51 +7,59 @@
             @php
                 $settingsRoute = Route::has('settings.index') ? route('settings.index') : url('/');
             @endphp
-            <a href="{{ $settingsRoute }}" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            <a href="{{ $settingsRoute }}" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-gray-700 bg-gray-100 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-300">
                 {{ __('Back to Settings') }}
             </a>
         </div>
     </x-slot>
 
-    <div class="py-10">
+    <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
-                <div class="px-4 py-5 sm:p-6">
-                    <p class="text-sm text-gray-600">
-                        {{ __('Review the available email templates and click edit to update the Blade markup used when EventSchedule sends each message.') }}
-                    </p>
-
-                    <div class="mt-6 border-t border-gray-200"></div>
-
-                    <div class="mt-6">
-                        <ul role="list" class="divide-y divide-gray-200">
-                            @forelse ($templates as $template)
-                                <li class="py-4">
-                                    <div class="flex items-center justify-between">
-                                        <div>
-                                            <p class="text-sm font-medium text-gray-900">
-                                                {{ $template['label'] }}
-                                            </p>
-                                            <p class="text-sm text-gray-500">
-                                                {{ $template['relative'] }}
-                                            </p>
-                                        </div>
-                                        <div class="flex space-x-3">
-                                            <a href="{{ route('settings.email-templates.edit', ['template' => $template['key']]) }}" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                                                {{ __('Edit') }}
-                                            </a>
-                                        </div>
-                                    </div>
-                                </li>
-                            @empty
-                                <li class="py-4">
-                                    <p class="text-sm text-gray-500">
-                                        {{ __('No email templates were found in the expected directories.') }}
-                                    </p>
-                                </li>
-                            @endforelse
-                        </ul>
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <div class="mb-6">
+                        <p class="text-sm text-gray-600">
+                            {{ __('Email templates control the text that EventSchedule sends to your attendees. Select a template below to review or customise it.') }}
+                        </p>
                     </div>
+
+                    @if (count($templates) === 0)
+                        <div class="rounded-md bg-yellow-50 p-4">
+                            <div class="flex">
+                                <div class="flex-shrink-0">
+                                    <svg class="h-5 w-5 text-yellow-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l6.451 11.48C18.944 15.943 18.094 17 16.823 17H3.177c-1.27 0-2.121-1.057-1.371-2.421l6.451-11.48zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-.25-5.75a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z" clip-rule="evenodd" />
+                                    </svg>
+                                </div>
+                                <div class="ml-3">
+                                    <h3 class="text-sm font-medium text-yellow-800">{{ __('No email templates were found in the expected directories.') }}</h3>
+                                    <div class="mt-2 text-sm text-yellow-700">
+                                        <p>{{ __('Add Blade templates under resources/views/emails, mail, email, or mailers to manage them here.') }}</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    @else
+                        <div class="flow-root">
+                            <ul role="list" class="-my-5 divide-y divide-gray-200">
+                                @foreach ($templates as $template)
+                                    <li class="py-4">
+                                        <div class="flex items-center justify-between">
+                                            <div>
+                                                <p class="text-sm font-medium text-gray-900">{{ $template['label'] }}</p>
+                                                <p class="text-sm text-gray-500">{{ $template['relative'] }}</p>
+                                            </div>
+                                            <div class="ml-4">
+                                                <a href="{{ route('settings.email-templates.edit', ['template' => $template['key']]) }}" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                                    {{ __('Edit') }}
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add a dedicated Email Templates index view with improved empty state messaging and navigation back to Settings
- provide an edit view that surfaces success feedback and a styled textarea for template contents

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb74623824832ea038352216a568bb