### PR TITLE
Improve email template settings injection

### DIFF
--- a/scripts/customize_email_templates.php
+++ b/scripts/customize_email_templates.php
@@ -44,10 +44,33 @@ if (is_file($webPath)) {
     file_put_contents($webPath, $code);
 }
 
-$settingsPaths = [
-    $base . '/resources/views/settings/index.blade.php',
-    $base . '/resources/views/settings.blade.php',
-];
+$settingsPaths = [];
+
+$settingsDir = $base . '/resources/views/settings';
+if (is_dir($settingsDir)) {
+    $iterator = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($settingsDir, \RecursiveDirectoryIterator::SKIP_DOTS)
+    );
+
+    foreach ($iterator as $file) {
+        if (!$file->isFile()) {
+            continue;
+        }
+
+        if (!str_ends_with($file->getFilename(), '.blade.php')) {
+            continue;
+        }
+
+        $settingsPaths[] = $file->getPathname();
+    }
+}
+
+$rootSettingsView = $base . '/resources/views/settings.blade.php';
+if (is_file($rootSettingsView)) {
+    $settingsPaths[] = $rootSettingsView;
+}
+
+$settingsPaths = array_values(array_unique($settingsPaths));
 
 $noteBlock = <<<'NOTE'
     <div class="mt-8 bg-yellow-50 border-l-4 border-yellow-400 p-4 rounded-md settings-mail-warning">
@@ -100,10 +123,10 @@ foreach ($settingsPaths as $settingsPath) {
         }
 
         if ($pos === false) {
-            $contents .= $insertion;
-        } else {
-            $contents = substr_replace($contents, $insertion, $pos, 0);
+            continue;
         }
+
+        $contents = substr_replace($contents, $insertion, $pos, 0);
     }
 
     file_put_contents($settingsPath, $contents);


### PR DESCRIPTION
## Summary
- broaden the customization script to scan the full settings view tree when adding the Manage email templates callout
- skip files without a recognizable layout marker so partials are not modified unintentionally

## Testing
- php -l scripts/customize_email_templates.php

------
https://chatgpt.com/codex/tasks/task_e_68cb79d8ecfc832e941ccda7fded9a30