### PR TITLE
Refactor settings bootstrap script invocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,61 +61,7 @@ COPY routes/_sign_up_override.php /var/www/html/routes/_sign_up_override.php
 RUN printf "\n// Allow public sign up without redirecting to /login\nrequire __DIR__.'/_sign_up_override.php';\n" >> routes/web.php
 
 # Skip settings bootstrap when no DB is available (eg. during image build)
-RUN php <<'PHP'
-<?php
-$dir = __DIR__ . '/app/Providers';
-if (!is_dir($dir)) {
-    exit;
-}
-
-$iterator = new RecursiveIteratorIterator(
-    new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
-);
-
-$pattern = '/(^[ \t]*)if\s*\(\s*Schema::hasTable\(\'settings\'\)\s*\)\s*(?<block>\{(?:[^{}]+|(?&block))*\})/m';
-
-foreach ($iterator as $file) {
-    if (!$file->isFile() || $file->getExtension() !== 'php') {
-        continue;
-    }
-
-    $path = $file->getPathname();
-    $code = file_get_contents($path);
-
-    if (strpos($code, "Schema::hasTable('settings')") === false) {
-        continue;
-    }
-
-    if (strpos($code, '$this->app->runningInConsole()') !== false) {
-        continue;
-    }
-
-    $newCode = preg_replace_callback($pattern, function (array $matches) {
-        $indent = $matches[1];
-        $block = $matches[0];
-
-        $indentPattern = '/^' . preg_quote($indent, '/') . '/m';
-        $blockIndented = preg_replace($indentPattern, $indent . '    ', $block);
-
-        return $indent . "if (\$this->app->runningInConsole()) {\n"
-            . $indent . "    return;\n"
-            . $indent . "}\n\n"
-            . $indent . "try {\n"
-            . $blockIndented . "\n"
-            . $indent . "} catch (\\Throwable \$e) {\n"
-            . $indent . "    return;\n"
-            . $indent . "}\n";
-    }, $code, 1, $replacements);
-
-    if ($replacements) {
-        if ($newCode !== '' && substr($newCode, -1) !== "\n") {
-            $newCode .= "\n";
-        }
-
-        file_put_contents($path, $newCode);
-    }
-}
-PHP
+RUN php -r 'eval(base64_decode("JGRpciA9IF9fRElSX18gLiAnL2FwcC9Qcm92aWRlcnMnOwppZiAoIWlzX2RpcigkZGlyKSkgewogICAgZXhpdDsKfQoKJGl0ZXJhdG9yID0gbmV3IFJlY3Vyc2l2ZUl0ZXJhdG9ySXRlcmF0b3IoCiAgICBuZXcgUmVjdXJzaXZlRGlyZWN0b3J5SXRlcmF0b3IoJGRpciwgRmlsZXN5c3RlbUl0ZXJhdG9yOjpTS0lQX0RPVFMpCik7CgokcGF0dGVybiA9ICcvKF5bIFx0XSopaWZccypcKFxzKlNjaGVtYTo6aGFzVGFibGVcKCcnc2V0dGluZ3MnJ1wpXHMqKD88YmxvY2s+XHsoPzpbXnt9XSt8KD8mYmxvY2spKSpcfSkvbSc7Cgpmb3JlYWNoICgkaXRlcmF0b3IgYXMgJGZpbGUpIHsKICAgIGlmICghJGZpbGUtPmlzRmlsZSgpIHx8ICRmaWxlLT5nZXRFeHRlbnNpb24oKSAhPT0gJ3BocCcpIHsKICAgICAgICBjb250aW51ZTsKICAgIH0KCiAgICAkcGF0aCA9ICRmaWxlLT5nZXRQYXRobmFtZSgpOwogICAgJGNvZGUgPSBmaWxlX2dldF9jb250ZW50cygkcGF0aCk7CgogICAgaWYgKHN0cnBvcygkY29kZSwgIlNjaGVtYTo6aGFzVGFibGUoJ3NldHRpbmdzJykiKSA9PT0gZmFsc2UpIHsKICAgICAgICBjb250aW51ZTsKICAgIH0KCiAgICBpZiAoc3RycG9zKCRjb2RlLCAnJHRoaXMtPmFwcC0+cnVubmluZ0luQ29uc29sZSgpJykgIT09IGZhbHNlKSB7CiAgICAgICAgY29udGludWU7CiAgICB9CgogICAgJG5ld0NvZGUgPSBwcmVnX3JlcGxhY2VfY2FsbGJhY2soJHBhdHRlcm4sIGZ1bmN0aW9uIChhcnJheSAkbWF0Y2hlcykgewogICAgICAgICRpbmRlbnQgPSAkbWF0Y2hlc1sxXTsKICAgICAgICAkYmxvY2sgPSAkbWF0Y2hlc1swXTsKCiAgICAgICAgJGluZGVudFBhdHRlcm4gPSAnL14nIC4gcHJlZ19xdW90ZSgkaW5kZW50LCAnLycpIC4gJy9tJzsKICAgICAgICAkYmxvY2tJbmRlbnRlZCA9IHByZWdfcmVwbGFjZSgkaW5kZW50UGF0dGVybiwgJGluZGVudCAuICcgICAgJywgJGJsb2NrKTsKCiAgICAgICAgcmV0dXJuICRpbmRlbnQgLiAiaWYgKCR0aGlzLT5hcHAtPnJ1bm5pbmdJbkNvbnNvbGUoKSkge1xuIgogICAgICAgICAgICAuICRpbmRlbnQgLiAiICAgIHJldHVybjtcbiIKICAgICAgICAgICAgLiAkaW5kZW50IC4gIn1cblxuIgogICAgICAgICAgICAuICRpbmRlbnQgLiAidHJ5IHtcbiIKICAgICAgICAgICAgLiAkYmxvY2tJbmRlbnRlZCAuICJcbiIKICAgICAgICAgICAgLiAkaW5kZW50IC4gIn0gY2F0Y2ggKFxcVGhyb3dhYmxlICRlKSB7XG4iCiAgICAgICAgICAgIC4gJGluZGVudCAuICIgICAgcmV0dXJuO1xuIgogICAgICAgICAgICAuICRpbmRlbnQgLiAifVxuIjsKICAgIH0sICRjb2RlLCAxLCAkcmVwbGFjZW1lbnRzKTsKCiAgICBpZiAoJHJlcGxhY2VtZW50cykgewogICAgICAgIGlmICgkbmV3Q29kZSAhPT0gJycgJiYgc3Vic3RyKCRuZXdDb2RlLCAtMSkgIT09ICJcbiIpIHsKICAgICAgICAgICAgJG5ld0NvZGUgLj0gIlxuIjsKICAgICAgICB9CgogICAgICAgIGZpbGVfcHV0X2NvbnRlbnRzKCRwYXRoLCAkbmV3Q29kZSk7CiAgICB9Cn0K"));'
 
 # PHP deps
 RUN composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader \


### PR DESCRIPTION
## Summary
- replace the heredoc-based php CLI call in the Dockerfile with a parser-friendly php -r invocation
- keep the settings bootstrap guard logic intact by base64-encoding the original script for eval at build time

## Testing
- docker compose build *(fails: docker binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1e389984832e91e12f7e324b4417