### PR TITLE
Handle leading backslash when patching AppServiceProvider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ RUN git clone --depth 1 --branch "${APP_REF}" https://github.com/eventschedule/e
 RUN git config --global --add safe.directory /var/www/html
 
 # Gate any forceScheme('https') behind FORCE_HTTPS
-RUN grep -q "forceScheme('https')" app/Providers/AppServiceProvider.php \
-  && sed -i "s/URL::forceScheme('https');/if (env('FORCE_HTTPS', false)) { URL::forceScheme('https'); }/" app/Providers/AppServiceProvider.php \
-  || true
+COPY scripts/force_https_patch.php /tmp/force_https_patch.php
+RUN php /tmp/force_https_patch.php /var/www/html \
+ && rm /tmp/force_https_patch.php
 
 # Ensure .env exists BEFORE composer (artisan post-scripts expect it)
 RUN [ -f .env ] || cp .env.example .env

--- a/scripts/force_https_patch.php
+++ b/scripts/force_https_patch.php
@@ -1,0 +1,25 @@
+<?php
+$basePath = $argv[1] ?? null;
+if ($basePath === null) {
+    fwrite(STDERR, "Usage: php force_https_patch.php <path>\n");
+    exit(1);
+}
+$file = rtrim($basePath, "\/") . '/app/Providers/AppServiceProvider.php';
+if (!file_exists($file)) {
+    exit(0);
+}
+$contents = file_get_contents($file);
+if ($contents === false) {
+    fwrite(STDERR, "Unable to read {$file}\n");
+    exit(1);
+}
+$replacement = "if (env('FORCE_HTTPS', false)) { URL::forceScheme('https'); }";
+$count = 0;
+if (str_contains($contents, "\\URL::forceScheme('https');")) {
+    $contents = str_replace("\\URL::forceScheme('https');", $replacement, $contents, $count);
+} elseif (str_contains($contents, "URL::forceScheme('https');")) {
+    $contents = str_replace("URL::forceScheme('https');", $replacement, $contents, $count);
+}
+if ($count > 0) {
+    file_put_contents($file, $contents);
+}


### PR DESCRIPTION
## Summary
- replace the Docker sed step with a PHP helper script that safely guards URL::forceScheme calls
- handle AppServiceProvider implementations that prefix URL::forceScheme with a leading backslash to avoid syntax errors

## Testing
- php -l scripts/force_https_patch.php

------
https://chatgpt.com/codex/tasks/task_e_68cc31479b34832eac0d521fc460884c