### PR TITLE
Replace AppServiceProvider during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ RUN git clone --depth 1 --branch "${APP_REF}" https://github.com/eventschedule/e
 # Fix "dubious ownership"
 RUN git config --global --add safe.directory /var/www/html
 
+# Replace AppServiceProvider with a version compatible with non-interactive builds
+COPY patches/AppServiceProvider.php /tmp/AppServiceProvider.php
+RUN cp /tmp/AppServiceProvider.php /var/www/html/app/Providers/AppServiceProvider.php \
+ && rm /tmp/AppServiceProvider.php
+
 # Gate any forceScheme('https') behind FORCE_HTTPS
 COPY scripts/force_https_patch.php /tmp/force_https_patch.php
 RUN php /tmp/force_https_patch.php /var/www/html \

--- a/patches/AppServiceProvider.php
+++ b/patches/AppServiceProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        Schema::defaultStringLength(191);
+
+        // Allow Docker image patch script to gate HTTPS forcing behind env var.
+        URL::forceScheme('https');
+
+        if ($this->app->runningInConsole()) {
+            return;
+        }
+
+        if (!class_exists(\App\Models\Setting::class)) {
+            return;
+        }
+
+        try {
+            if (Schema::hasTable('settings')) {
+                $settings = \App\Models\Setting::query()
+                    ->get(['name', 'value'])
+                    ->pluck('value', 'name')
+                    ->toArray();
+
+                foreach ($settings as $key => $value) {
+                    config(["settings.$key" => $value]);
+                }
+
+                View::share('globalSettings', $settings);
+            }
+        } catch (\Throwable $e) {
+            // During image build we do not have a database, so swallow errors.
+            return;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a patched AppServiceProvider implementation that is safe to load during composer scripts
- copy the patched provider into the cloned application before running build-time patches

## Testing
- docker build --target app . *(fails: docker command not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4129ca3c832eabd2c90c1c9fa3c1