### PR TITLE
Increase upload size limits to 500MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@ RUN docker-php-ext-configure gd --with-jpeg --with-freetype \
  && docker-php-ext-install \
     pdo pdo_mysql mbstring exif pcntl bcmath intl opcache zip gd
 
+# Raise PHP upload limits to accommodate large files
+RUN { \
+      echo 'upload_max_filesize=500M'; \
+      echo 'post_max_size=500M'; \
+    } > /usr/local/etc/php/conf.d/uploads.ini
+
 # Composer
 ENV COMPOSER_ALLOW_SUPERUSER=1 COMPOSER_MEMORY_LIMIT=-1
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,7 @@ server {
   server_name _;
   root /var/www/html/public;
   index index.php index.html;
+  client_max_body_size 500M;
 
   # Map legacy /register to the real /sign_up
   location = /register {


### PR DESCRIPTION
## Summary
- raise PHP's upload_max_filesize and post_max_size limits to 500 MB during the image build
- configure nginx to allow 500 MB request bodies so uploads are not rejected at the proxy layer

## Testing
- `docker compose config` *(fails: docker not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd461cc254832eb48f9e763e30ce64