### PR TITLE
Ensure app files owned by www-data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,9 @@ RUN mkdir -p storage bootstrap/cache \
  && chown -R www-data:www-data storage bootstrap public \
  && php artisan storage:link || true
 
+# Ensure application code is owned by www-data
+RUN chown -R www-data:www-data /var/www/html
+
 # Entrypoint
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- ensure the image build explicitly sets ownership of /var/www/html to www-data so runtime permissions are correct

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3e8e73498832e92d1d63adc080464