### PR TITLE
Document published image usage and tag workflow outputs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,11 +35,29 @@ jobs:
         with:
           images: ${{ secrets.DOCKERHUB_REPOSITORY }}
 
-      - name: Build and push Docker image
+      - name: Build and push PHP-FPM app image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
+          target: app
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ secrets.DOCKERHUB_REPOSITORY }}:app
+            ${{ secrets.DOCKERHUB_REPOSITORY }}:app-${{ github.sha }}
+            ${{ secrets.DOCKERHUB_REPOSITORY }}:scheduler
+            ${{ secrets.DOCKERHUB_REPOSITORY }}:scheduler-${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push Nginx web image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          target: web
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ secrets.DOCKERHUB_REPOSITORY }}:web
+            ${{ secrets.DOCKERHUB_REPOSITORY }}:web-${{ github.sha }}
+            ${{ secrets.DOCKERHUB_REPOSITORY }}:latest
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -27,10 +27,33 @@ This repository provides a Docker-based runtime for the [EventSchedule](https://
    mkdir -p data/{db,storage,vendor,node_modules}
    ```
 
-3. Start the stack:
-   ```bash
-   docker compose up --build -d
-   ```
+3. Start the stack. Choose the workflow that matches your situation:
+
+   - **Build locally:**
+     ```bash
+     docker compose up --build -d
+     ```
+     This rebuilds the `eventschedule/app:local`, `eventschedule/web:local`, and
+     `eventschedule/scheduler:local` images on your machine and then boots the
+     stack.
+
+   - **Use images published by GitHub Actions:**
+     ```bash
+     export APP_IMAGE="<dockerhub-repo>:app"
+     export WEB_IMAGE="<dockerhub-repo>:web"
+     export SCHEDULER_IMAGE="<dockerhub-repo>:scheduler"
+     docker compose pull
+     docker compose up -d --no-build
+     ```
+     Replace `<dockerhub-repo>` with the repository you configured in
+     `.github/.dockerhub-credentials` (for example `acme/eventschedule`). The
+     workflow pushes tags for each service (`:app`, `:web`, and `:scheduler`),
+     allowing `docker compose` to pull the artifacts instead of rebuilding
+     locally.
+
+   > **Tip:** Running `docker build` alone only produces the PHP-FPM image from
+   > the `Dockerfile`. Use `docker compose up` so the `web`, `db`, and
+   > `scheduler` services start alongside the `app` container.
 4. Visit [http://localhost:8080](http://localhost:8080) to access the application.
 
 The first startup can take several minutes while dependencies are installed and assets are compiled.
@@ -60,13 +83,7 @@ The Dockerfile clones the upstream EventSchedule repository. You can change the 
 ## Publishing Images with GitHub Actions
 
 This repository ships with a reusable GitHub Actions workflow that can build and
-publish the Docker image straight to Docker Hub. To authenticate with your own
-registry account:
-
-## Publishing Images with GitHub Actions
-
-This repository ships with a reusable GitHub Actions workflow that can build and
-publish the Docker image straight to Docker Hub. To authenticate with your own
+publish the Docker images straight to Docker Hub. To authenticate with your own
 registry account:
 
 1. Copy the bundled credentials template and update it with your Docker Hub
@@ -92,12 +109,14 @@ Once those secrets are configured, you can trigger the workflow in either of two
 ways:
 
 - Push or merge changes into the `main` branch. The workflow will build the
-  image and push the tagged artifacts to Docker Hub automatically.
+  images and push the tagged artifacts to Docker Hub automatically.
 - Run the workflow manually from the **Actions** tab by selecting “Build and
   Publish Docker image” and clicking **Run workflow**.
 
-Pull requests continue to run the workflow in build-only mode so you can confirm
-the Dockerfile still builds without publishing artifacts.
+The workflow publishes three tags—`:app`, `:web`, and `:scheduler`—along with
+per-commit variants (e.g., `:web-<sha>`). Pull requests continue to run the
+workflow in build-only mode so you can confirm the Dockerfile still builds
+without publishing artifacts.
 
 ## Changelog
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   app:
+    image: ${APP_IMAGE:-eventschedule/app:local}
     build:
       context: .
       dockerfile: Dockerfile
@@ -26,6 +27,7 @@ services:
       retries: 30
 
   web:
+    image: ${WEB_IMAGE:-eventschedule/web:local}
     build:
       context: .
       dockerfile: Dockerfile
@@ -57,6 +59,7 @@ services:
     restart: unless-stopped
 
   scheduler:
+    image: ${SCHEDULER_IMAGE:-eventschedule/scheduler:local}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- allow docker compose services to reference configurable image tags so published artifacts can be pulled instead of rebuilt
- document how to start the stack using either locally built images or workflow-published images
- update the Docker publish workflow to push app, web, and scheduler tags for each build

## Testing
- not run (documentation and workflow updates only)

------
https://chatgpt.com/codex/tasks/task_e_68eae8334ea0832ea0dd91427644f2f5