### PR TITLE
Add compose override example for shared host environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,33 @@ This repository provides a Docker-based runtime for the [EventSchedule](https://
 
 The first startup can take several minutes while dependencies are installed and assets are compiled.
 
+### Running alongside other Docker projects
+
+If you already have other Compose stacks running on your machine, use the
+provided [`docker-compose.extras.example.yml`](docker-compose.extras.example.yml)
+as an override file so EventSchedule can share the host without port
+collisions. The override adjusts the published ports and optionally connects the
+services to a shared user-defined bridge network so they can be discovered by an
+existing reverse proxy or other containers.
+
+1. Create the shared network if you want the stack to communicate with other
+   Compose projects:
+
+   ```bash
+   docker network create shared-services
+   ```
+
+2. Start the stack with the override to publish alternate ports (change the
+   `WEB_PORT` and `DB_HOST_PORT` values if you prefer different mappings):
+
+   ```bash
+   WEB_PORT=18080 DB_HOST_PORT=13306 \
+   docker compose -f docker-compose.yml -f docker-compose.extras.example.yml up -d
+   ```
+
+   To use a different external network name, set `SHARED_NETWORK=<network>` when
+   running the command or edit the override file to match your environment.
+
 ## Service Overview
 
 | Service    | Description                                                                 |

--- a/docker-compose.extras.example.yml
+++ b/docker-compose.extras.example.yml
@@ -1,0 +1,31 @@
+# Example override file for running EventSchedule alongside existing Docker stacks.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.extras.example.yml up -d
+#
+# Customize host ports and optionally join an external shared network so the
+# stack can coexist with other services already running on the host.
+services:
+  web:
+    # Change the HTTP host port if 8080 is already in use.
+    ports:
+      - "${WEB_PORT:-18080}:80"
+    networks:
+      - default
+      - shared-services
+
+  db:
+    # Expose MariaDB on a non-standard port to avoid clashing with other databases.
+    ports:
+      - "${DB_HOST_PORT:-13306}:3306"
+    networks:
+      - default
+      - shared-services
+
+networks:
+  shared-services:
+    # Attach to an existing user-defined bridge network so reverse proxies or other
+    # containers can discover the EventSchedule services. Comment this block out if
+    # you do not need cross-stack communication.
+    external: true
+    name: ${SHARED_NETWORK:-shared-services}


### PR DESCRIPTION
## Summary
- add a docker compose override example that remaps ports and optionally joins an external shared network
- document how to launch the stack alongside other Docker projects using the new example file

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68eaeb2126dc832eafabb047899ea755