### PR TITLE
Set DB host for containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         APP_REF: main
     env_file: .env
     environment:
+      DB_HOST: db
       DB_PASSWORD: ${DB_PASSWORD:-change_me}
     depends_on:
       db:
@@ -71,6 +72,7 @@ services:
         condition: service_healthy
     env_file: .env
     environment:
+      DB_HOST: db
       DB_PASSWORD: ${DB_PASSWORD:-change_me}
     command: ["sh", "-lc", "while :; do php artisan schedule:run --verbose --no-interaction || true; sleep 60; done"]
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- override the DB host for the Laravel app and scheduler containers so they point at the bundled MariaDB service
- ensure migrations and runtime database connections succeed even when the default .env file still uses 127.0.0.1

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68eaed1db500832eb6c2d1d1e17dae82