### PR TITLE
Ensure vendor dependencies installed at runtime

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,6 +6,12 @@ cd /var/www/html
 # Ensure .env exists
 [ -f .env ] || cp .env.example .env
 
+# Ensure Composer dependencies when vendor volume is empty
+if [ ! -f vendor/autoload.php ]; then
+  echo "Installing Composer dependencies..."
+  composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader
+fi
+
 # Wait for DB (best-effort)
 if [ -n "$DB_HOST" ]; then
   echo "Waiting for DB at ${DB_HOST}:${DB_PORT:-3306}..."


### PR DESCRIPTION
## Summary
- install Composer dependencies during container startup when the mounted vendor directory is empty

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68eaeeaa7fac832ea33933c4fd35b0f2