### PR TITLE
Ensure scheduler container runs entrypoint script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
     environment:
       DB_HOST: db
       DB_PASSWORD: ${DB_PASSWORD:-change_me}
+    entrypoint: ["/usr/local/bin/docker-entrypoint.sh"]
     command: ["sh", "-lc", "while :; do php artisan schedule:run --verbose --no-interaction || true; sleep 60; done"]
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary
- ensure the scheduler service executes the shared entrypoint so Composer dependencies are installed before running artisan

## Testing
- not run (docker CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68eaf1370878832eaba31025d1a450db