### PR TITLE
Ensure vendor dependencies persist when using bind mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,9 @@ RUN php /tmp/skip_settings_bootstrap.php /var/www/html \
 
 # PHP deps
 RUN composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader \
- && mv .env.dockerbuild .env
+ && mv .env.dockerbuild .env \
+ && mkdir -p /opt/app-bootstrap \
+ && cp -a vendor /opt/app-bootstrap/vendor
 
 # Frontend build (tolerant)
 RUN [ -f package-lock.json ] && npm ci || true

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,16 @@ cd /var/www/html
 
 # Ensure Composer dependencies when vendor volume is empty
 if [ ! -f vendor/autoload.php ]; then
+  if [ -d /opt/app-bootstrap/vendor ]; then
+    echo "Populating vendor directory from image cache..."
+    mkdir -p vendor
+    if ! cp -a /opt/app-bootstrap/vendor/. vendor/; then
+      echo "Unable to copy cached vendor directory, will run composer install instead."
+    fi
+  fi
+fi
+
+if [ ! -f vendor/autoload.php ]; then
   echo "Installing Composer dependencies..."
   composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader
 fi


### PR DESCRIPTION
## Summary
- cache the Composer vendor directory during the image build
- restore the cached dependencies when a bind-mounted vendor volume is empty before falling back to composer install

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eaf3adbdc8832e9df46bad35253a03