### PR TITLE
Restore bind-mounted dependency volumes

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -54,6 +54,17 @@ acquire_vendor_dependencies() {
 
 acquire_vendor_dependencies
 
+if [ ! -f vendor/autoload.php ]; then
+  cat >&2 <<'EOF'
+ERROR: Unable to locate vendor/autoload.php after preparing Composer dependencies.
+This usually means the bind-mounted vendor directory is not writable or the
+dependency installation failed silently. Please verify the permissions of
+./data/vendor on the host and rerun the container so dependencies can be
+installed.
+EOF
+  exit 1
+fi
+
 # Wait for DB (best-effort)
 if [ -n "$DB_HOST" ]; then
   echo "Waiting for DB at ${DB_HOST}:${DB_PORT:-3306}..."


### PR DESCRIPTION
## Summary
- revert the app and scheduler services to bind-mount the vendor and node_modules directories from the host
- update the README to again describe the bind-mounted directories and optional host setup step
- clarify the entrypoint guidance so it points to the ./data/vendor bind mount when dependencies are missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb037c3a40832eb55927ca1566bd8c