### PR TITLE
Handle stale vendor lock directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ The Dockerfile clones the upstream EventSchedule repository. You can change the 
 - **Migrations**: The entrypoint runs `php artisan migrate --force` on startup. Run additional artisan commands via `docker compose exec app php artisan ...`.
 - **Database access**: Connect to MariaDB on `localhost:3306` (when exposed) using credentials defined in `.env`.
 - **Updating dependencies**: Rebuild the `app` image (`docker compose build app`) after modifying Composer or npm dependencies.
+- **Stuck dependency install**: The containers coordinate Composer installs with a lock directory inside `vendor/`. If a previous
+  run was interrupted and the lock remains, the entrypoint automatically clears it after 15 minutes so dependencies can be
+  reinstalled. You can override the timeout by setting `VENDOR_LOCK_TIMEOUT_SECONDS` in `.env`.
 
 ## Publishing Images with GitHub Actions
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,28 @@ cd /var/www/html
 # Ensure Composer dependencies when vendor volume is empty
 mkdir -p vendor
 vendor_lock="vendor/.installing-dependencies"
+vendor_lock_timeout="${VENDOR_LOCK_TIMEOUT_SECONDS:-900}"
+
+is_lock_stale() {
+  [ ! -d "$vendor_lock" ] && return 1
+
+  if [ -f "$vendor_lock/.timestamp" ]; then
+    lock_created=$(cat "$vendor_lock/.timestamp" 2>/dev/null || printf '0')
+  else
+    lock_created=$(stat -c %Y "$vendor_lock" 2>/dev/null || printf '0')
+  fi
+
+  lock_created=${lock_created%%[^0-9]*}
+  [ -z "$lock_created" ] && lock_created=0
+
+  now=$(date +%s)
+  [ "$lock_created" -eq 0 ] && return 0
+
+  age=$((now - lock_created))
+  [ "$age" -lt 0 ] && return 1
+
+  [ "$age" -ge "$vendor_lock_timeout" ]
+}
 
 cleanup_vendor_lock() {
   if [ -d "$vendor_lock" ]; then
@@ -22,6 +44,7 @@ acquire_vendor_dependencies() {
 
   while [ ! -f vendor/autoload.php ]; do
     if mkdir "$vendor_lock" 2>/dev/null; then
+      date +%s >"$vendor_lock/.timestamp" 2>/dev/null || true
       if [ -d /opt/app-bootstrap/vendor ]; then
         echo "Populating vendor directory from image cache..."
         if ! cp -a /opt/app-bootstrap/vendor/. vendor/; then
@@ -40,6 +63,11 @@ acquire_vendor_dependencies() {
     fi
 
     if [ -d "$vendor_lock" ]; then
+      if is_lock_stale; then
+        echo "Vendor dependency lock appears stale. Removing it so dependencies can be installed..."
+        rm -rf "$vendor_lock"
+        continue
+      fi
       echo "Waiting for another container to finish installing Composer dependencies..."
     else
       echo "Unable to create vendor lock directory '$vendor_lock'. Check volume permissions." >&2


### PR DESCRIPTION
## Summary
- add stale lock detection in the entrypoint so Composer can recover from abandoned vendor locks
- document the new `VENDOR_LOCK_TIMEOUT_SECONDS` option for adjusting the stale lock timeout

## Testing
- sh -n docker-entrypoint.sh


------
https://chatgpt.com/codex/tasks/task_e_68eb0af41424832eb79a414643ca7c16