### PR TITLE
Fix sign up override controller invocation

### DIFF
--- a/routes/_sign_up_override.php
+++ b/routes/_sign_up_override.php
@@ -15,7 +15,7 @@ Route::middleware('guest')->group(function () {
         // Fallback: call the app's controller if the view isn't present
         if (class_exists(\App\Http\Controllers\Auth\RegisteredUserController::class)) {
             return app(\App\Http\Controllers\Auth\RegisteredUserController::class)
-                ->create(request());
+                ->create();
         }
 
         abort(404);


### PR DESCRIPTION
## Summary
- stop passing the current request into the fallback RegisteredUserController::create handler to match Laravel's expected signature

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb1b3160bc832e8e2ec331fd4d5731