### PR TITLE
Revert "Fail fast when Composer vendor directory is unavailable"

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -54,17 +54,6 @@ acquire_vendor_dependencies() {
 
 acquire_vendor_dependencies
 
-if [ ! -f vendor/autoload.php ]; then
-  cat >&2 <<'EOF'
-ERROR: Unable to locate vendor/autoload.php after preparing Composer dependencies.
-This usually means the bind-mounted vendor volume is not writable or the
-dependency installation failed silently. Please verify the permissions of the
-./data/vendor directory (or the configured vendor volume) and rerun the
-container so dependencies can be installed.
-EOF
-  exit 1
-fi
-
 # Wait for DB (best-effort)
 if [ -n "$DB_HOST" ]; then
   echo "Waiting for DB at ${DB_HOST}:${DB_PORT:-3306}..."


### PR DESCRIPTION
Reverts dfiore1230/eventsscheduler-docker#31