### PR TITLE
Add prebuilt single-container compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,50 @@ named Docker volumes.
 The container defaults to SQLite. If you would rather connect to an external MySQL or MariaDB instance, set `USE_SQLITE=0` and
 provide the usual database environment variables in `.env` before starting the stack.
 
+## Using the Prebuilt Docker Hub Image
+
+If you would prefer to start from the published image rather than building the
+Dockerfile in this repository, pull
+[`dfiore/eventsschedule:latest`](https://hub.docker.com/r/dfiore/eventsschedule)
+from Docker Hub. You can create a thin wrapper Dockerfile that layers
+environment defaults, assets, or other customizations on top of the prebuilt
+runtime:
+
+```Dockerfile
+FROM dfiore/eventsschedule:latest
+
+# Example override: copy a production-ready .env into the container
+# COPY .env.production /var/www/html/.env
+```
+
+See [`examples/Dockerfile.from-prebuilt`](examples/Dockerfile.from-prebuilt) for a
+fully annotated template that demonstrates common customization points while
+reusing the prebuilt container. When you are ready to run the full stack without
+rebuilding images, use the companion Compose file at
+[`examples/docker-compose.prebuilt.yml`](examples/docker-compose.prebuilt.yml):
+
+```bash
+cp .env.example .env
+docker compose -f examples/docker-compose.prebuilt.yml up -d
+```
+
+The Compose definition wires the published image into the standard `app`,
+`web`, and `scheduler` services while leaving the MariaDB dependency unchanged.
+
+Prefer the single-container topology? A matching prebuilt Compose file is
+available at
+[`examples/docker-compose.single-prebuilt.yml`](examples/docker-compose.single-prebuilt.yml):
+
+```bash
+cp .env.example .env
+mkdir -p bind/storage bind/database
+docker compose -f examples/docker-compose.single-prebuilt.yml up -d
+```
+
+This version layers the published image with bind mounts for the SQLite
+database and Laravel storage directories so you can persist uploads without
+creating named Docker volumes.
+
 ## Service Overview
 
 | Service    | Description                                                                 |

--- a/examples/Dockerfile.from-prebuilt
+++ b/examples/Dockerfile.from-prebuilt
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+# Example Dockerfile that reuses the prebuilt EventSchedule image published on Docker Hub.
+#
+# This is useful when you want to layer additional configuration, assets, or environment
+# defaults on top of the published container without rebuilding PHP, Composer dependencies,
+# or front-end assets yourself.
+
+FROM dfiore/eventsschedule:latest
+
+# Copy production environment configuration into the container (optional).
+# Uncomment and adjust the following lines to include your own environment file.
+# COPY .env.production /var/www/html/.env
+
+# Copy any additional application assets or overrides. For example, to bundle a
+# custom logo or theme that lives alongside this Dockerfile:
+# COPY branding/logo.svg /var/www/html/public/images/logo.svg
+
+# Run any one-time setup commands that should happen at build-time. Because the
+# upstream image already installs dependencies and caches configuration, keep
+# additional work minimal.
+# RUN php artisan config:cache
+
+# The base image exposes port 80 and defines an entrypoint that starts Nginx,
+# PHP-FPM, and the Laravel scheduler. No additional configuration is required
+# unless you need to change that behaviour.
+
+# Optionally, set or override environment variables directly in the Dockerfile.
+# These can also be provided at runtime with `docker run -e` or via Compose files.
+# ENV APP_ENV=production \
+#     APP_DEBUG=false \
+#     APP_URL=https://events.example.com
+
+# The default CMD inherited from the base image starts the application stack,
+# so there is nothing to override here.

--- a/examples/docker-compose.prebuilt.yml
+++ b/examples/docker-compose.prebuilt.yml
@@ -1,0 +1,79 @@
+version: "3.8"
+
+# This compose file demonstrates how to wire up the published
+# dfiore/eventsschedule:latest image without rebuilding from source.
+# Copy it next to your .env file, then run `docker compose -f docker-compose.prebuilt.yml up -d`.
+
+services:
+  app:
+    image: dfiore/eventsschedule:latest
+    pull_policy: if_not_present
+    env_file: ../.env
+    environment:
+      DB_PASSWORD: ${DB_PASSWORD:-change_me}
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - storage:/var/www/html/storage
+      - vendor:/var/www/html/vendor
+      - node_modules:/var/www/html/node_modules
+    entrypoint: ["/usr/local/bin/docker-entrypoint.sh"]
+    command: ["php-fpm", "-F"]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 9000"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  web:
+    image: dfiore/eventsschedule:latest
+    pull_policy: if_not_present
+    depends_on:
+      app:
+        condition: service_healthy
+    ports:
+      - "8080:80"
+    volumes:
+      - storage:/var/www/html/storage:ro
+    command: ["/usr/sbin/nginx", "-g", "daemon off;"]
+    restart: unless-stopped
+
+  db:
+    image: mariadb:11
+    environment:
+      MYSQL_DATABASE: eventschedule
+      MYSQL_USER: eventschedule
+      MYSQL_PASSWORD: ${DB_PASSWORD:-change_me}
+      MYSQL_ROOT_PASSWORD: rootpass
+    volumes:
+      - dbdata:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mariadb-admin", "ping", "-h", "127.0.0.1", "-uroot", "-prootpass"]
+      interval: 5s
+      timeout: 3s
+      retries: 40
+    restart: unless-stopped
+
+  scheduler:
+    image: dfiore/eventsschedule:latest
+    pull_policy: if_not_present
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file: ../.env
+    environment:
+      DB_PASSWORD: ${DB_PASSWORD:-change_me}
+    command: ["sh", "-lc", "while :; do php artisan schedule:run --verbose --no-interaction || true; sleep 60; done"]
+    restart: unless-stopped
+    volumes:
+      - storage:/var/www/html/storage
+      - vendor:/var/www/html/vendor
+      - node_modules:/var/www/html/node_modules
+
+volumes:
+  dbdata:
+  storage:
+  vendor:
+  node_modules:

--- a/examples/docker-compose.single-prebuilt.yml
+++ b/examples/docker-compose.single-prebuilt.yml
@@ -1,0 +1,28 @@
+version: "3.8"
+
+# This compose file runs the single-container variant from the
+# published dfiore/eventsschedule:latest image. It mirrors
+# docker-compose.single.yml but skips the build step so you can
+# launch immediately after preparing the bind mounts and .env file.
+
+services:
+  app:
+    image: dfiore/eventsschedule:latest
+    pull_policy: if_not_present
+    env_file: ../.env
+    environment:
+      USE_SQLITE: "1"
+    ports:
+      - "8080:80"
+    volumes:
+      - type: bind
+        source: ../bind/storage
+        target: /var/www/html/storage
+      - type: bind
+        source: ../bind/database
+        target: /var/www/html/database
+    entrypoint: ["/usr/local/bin/docker-entrypoint.sh"]
+    command: ["/usr/local/bin/start-single.sh"]
+    restart: unless-stopped
+
+volumes: {}


### PR DESCRIPTION
## Summary
- document how to launch the prebuilt image with the single-container topology
- add an example Compose definition that reuses the published image with SQLite bind mounts

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ebc1cff3dc832e91c768bd8ba021f4