### PR TITLE
Fix nginx config placement for Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ CMD ["php-fpm", "-F"]
 # =========================
 FROM nginx:1.27-alpine AS web
 COPY --from=app /var/www/html /var/www/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/nginx.conf
 RUN test -d /var/www/html/public
 
 
@@ -124,7 +124,7 @@ ENV INTERNAL_DB=1 \
 RUN apk add --no-cache nginx supervisor mariadb mariadb-client mariadb-backup \
  && mkdir -p /run/nginx /var/log/supervisor /run/mysqld /var/lib/mysql \
  && chown -R mysql:mysql /run/mysqld /var/lib/mysql
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/nginx.conf
 COPY scripts/supervisord-single.conf /etc/supervisord.conf
 EXPOSE 80
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,33 +1,52 @@
-server {
-  listen 80 default_server;
-  server_name _;
-  root /var/www/html/public;
-  index index.php index.html;
-  client_max_body_size 500M;
+user nginx;
+worker_processes auto;
 
-  # Map legacy /register to the real /sign_up
-  location = /register {
-    return 308 /sign_up;
-  }
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
 
-  location / {
-    try_files $uri $uri/ /index.php?$query_string;
-  }
-
-  location ~ \.php$ {
-    include fastcgi_params;
-    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    fastcgi_param PATH_INFO $fastcgi_path_info;
-    fastcgi_read_timeout 300;
-    fastcgi_param HTTPS $https if_not_empty;
-    fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
-    fastcgi_pass app:9000;
-  }
-
-  location ~* \.(css|js|jpg|jpeg|png|gif|ico|svg|webp|woff|woff2|ttf|eot)$ {
-    try_files $uri =404;
-    access_log off;
-    expires max;
-  }
+events {
+  worker_connections 1024;
 }
 
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  sendfile        on;
+  tcp_nopush      on;
+  tcp_nodelay     on;
+  keepalive_timeout  65;
+
+  server {
+    listen 80 default_server;
+    server_name _;
+    root /var/www/html/public;
+    index index.php index.html;
+    client_max_body_size 500M;
+
+    # Map legacy /register to the real /sign_up
+    location = /register {
+      return 308 /sign_up;
+    }
+
+    location / {
+      try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \\.php$ {
+      include fastcgi_params;
+      fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+      fastcgi_param PATH_INFO $fastcgi_path_info;
+      fastcgi_read_timeout 300;
+      fastcgi_param HTTPS $https if_not_empty;
+      fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+      fastcgi_pass app:9000;
+    }
+
+    location ~* \\.(css|js|jpg|jpeg|png|gif|ico|svg|webp|woff|woff2|ttf|eot)$ {
+      try_files $uri =404;
+      access_log off;
+      expires max;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace the nginx configuration with a full top-level config that wraps the site server block in an `http {}` context
- copy the config to `/etc/nginx/nginx.conf` in both web and single image stages so nginx loads it correctly on Alpine

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ebe788dd4c832eaa21c750ca2b89c2