### PR TITLE
Fix single container nginx upstream configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,7 @@ ENV INTERNAL_DB=1 \
 RUN apk add --no-cache nginx supervisor mariadb mariadb-client mariadb-backup \
  && mkdir -p /run/nginx /var/log/supervisor /run/mysqld /var/lib/mysql \
  && chown -R mysql:mysql /run/mysqld /var/lib/mysql
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.single.conf /etc/nginx/nginx.conf
 COPY scripts/supervisord-single.conf /etc/supervisord.conf
 EXPOSE 80
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/nginx.single.conf
+++ b/nginx.single.conf
@@ -1,0 +1,53 @@
+user nginx;
+worker_processes auto;
+
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  sendfile        on;
+  tcp_nopush      on;
+  tcp_nodelay     on;
+  keepalive_timeout  65;
+
+  server {
+    listen 80 default_server;
+    server_name _;
+    root /var/www/html/public;
+    index index.php index.html;
+    client_max_body_size 500M;
+
+    # Map legacy /register to the real /sign_up
+    location = /register {
+      return 308 /sign_up;
+    }
+
+    location / {
+      try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \\.php$ {
+      include fastcgi_params;
+      fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+      fastcgi_param PATH_INFO $fastcgi_path_info;
+      fastcgi_read_timeout 300;
+      fastcgi_param HTTPS $https if_not_empty;
+      fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+      fastcgi_pass 127.0.0.1:9000;
+    }
+
+    location ~* \\.(css|js|jpg|jpeg|png|gif|ico|svg|webp|woff|woff2|ttf|eot)$ {
+      try_files $uri =404;
+      access_log off;
+      expires max;
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated nginx configuration for the single-container image that targets the local php-fpm worker
- update the single image stage to install the single-container nginx config

## Testing
- not run (infrastructure change only)


------
https://chatgpt.com/codex/tasks/task_e_68ebe9e4a408832eacd9134a90957b9b