### PR TITLE
Provide default schedules view data

### DIFF
--- a/patches/AppServiceProvider.php
+++ b/patches/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\View;
+use Illuminate\View\View as ViewView;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -30,6 +31,12 @@ class AppServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             return;
         }
+
+        View::composer('*', function (ViewView $view): void {
+            if (!array_key_exists('schedules', $view->getData())) {
+                $view->with('schedules', collect());
+            }
+        });
 
         if (!class_exists(\App\Models\Setting::class)) {
             return;


### PR DESCRIPTION
## Summary
- register a global view composer that injects an empty schedules collection when the data is missing
- keep the existing settings hydration while ensuring HTTP views always have the schedules variable defined

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ebf35bfef4832e8381fb3203fdac9c