### PR TITLE
Ensure venues view data is always defined

### DIFF
--- a/patches/AppServiceProvider.php
+++ b/patches/AppServiceProvider.php
@@ -33,8 +33,14 @@ class AppServiceProvider extends ServiceProvider
         }
 
         View::composer('*', function (ViewView $view): void {
-            if (!array_key_exists('schedules', $view->getData())) {
+            $data = $view->getData();
+
+            if (!array_key_exists('schedules', $data)) {
                 $view->with('schedules', collect());
+            }
+
+            if (!array_key_exists('venues', $data)) {
+                $view->with('venues', collect());
             }
         });
 


### PR DESCRIPTION
## Summary
- ensure the global view composer seeds an empty venues collection when views do not provide one
- avoid repeated getData calls by reusing the retrieved data array

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebf5f7746c832ea91d7f1b4b45e3b7