### PR TITLE
Add default curators share to AppServiceProvider

### DIFF
--- a/patches/AppServiceProvider.php
+++ b/patches/AppServiceProvider.php
@@ -42,6 +42,10 @@ class AppServiceProvider extends ServiceProvider
             if (!array_key_exists('venues', $data)) {
                 $view->with('venues', collect());
             }
+
+            if (!array_key_exists('curators', $data)) {
+                $view->with('curators', collect());
+            }
         });
 
         if (!class_exists(\App\Models\Setting::class)) {


### PR DESCRIPTION
## Summary
- ensure the global view composer provides an empty `curators` collection when no data is passed
- prevent undefined variable errors in views that expect the `curators` variable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ebf829f07c832e9626885b39e89704