### PR TITLE
Fix fork URL typo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 # App source
 ARG APP_REF=main
 WORKDIR /var/www/html
-RUN git clone --depth 1 --branch "${APP_REF}" https://github.com/eventschedule/eventschedule.git /var/www/html
+RUN git clone --depth 1 --branch "${APP_REF}" https://github.com/dfiore1230/eventschedule.git /var/www/html
 
 # Fix "dubious ownership"
 RUN git config --global --add safe.directory /var/www/html


### PR DESCRIPTION
## Summary
- correct the fork URL in the Dockerfile to use the dfiore1230 namespace

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebfbc93ca8832e9af040b3416279fb