### PR TITLE
Seed default gradients.json into storage volume

### DIFF
--- a/.docker/storage-seeds/gradients.json
+++ b/.docker/storage-seeds/gradients.json
@@ -1,0 +1,22 @@
+[
+  {"from": "#ff9a9e", "to": "#fad0c4"},
+  {"from": "#a18cd1", "to": "#fbc2eb"},
+  {"from": "#fad0c4", "to": "#ffd1ff"},
+  {"from": "#ffecd2", "to": "#fcb69f"},
+  {"from": "#ff8177", "to": "#ff867a"},
+  {"from": "#ff9966", "to": "#ff5e62"},
+  {"from": "#fbc2eb", "to": "#a6c1ee"},
+  {"from": "#84fab0", "to": "#8fd3f4"},
+  {"from": "#cfd9df", "to": "#e2ebf0"},
+  {"from": "#f093fb", "to": "#f5576c"},
+  {"from": "#4facfe", "to": "#00f2fe"},
+  {"from": "#43e97b", "to": "#38f9d7"},
+  {"from": "#fa709a", "to": "#fee140"},
+  {"from": "#30cfd0", "to": "#330867"},
+  {"from": "#b2fefa", "to": "#0ed2f7"},
+  {"from": "#a1c4fd", "to": "#c2e9fb"},
+  {"from": "#667eea", "to": "#764ba2"},
+  {"from": "#f6d365", "to": "#fda085"},
+  {"from": "#a3bded", "to": "#6991c7"},
+  {"from": "#f5f7fa", "to": "#c3cfe2"}
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN git clone --depth 1 --branch "${APP_REF}" https://github.com/dfiore1230/even
 # Fix "dubious ownership"
 RUN git config --global --add safe.directory /var/www/html
 
+# Seed runtime storage defaults
+COPY .docker/storage-seeds /var/www/html/.docker/storage-seeds
+
 # Replace AppServiceProvider with a version compatible with non-interactive builds
 COPY patches/AppServiceProvider.php /tmp/AppServiceProvider.php
 RUN cp /tmp/AppServiceProvider.php /var/www/html/app/Providers/AppServiceProvider.php \

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,6 +15,10 @@ bootstrap_app() {
     bootstrap/cache \
     database
 
+  if [ ! -f storage/gradients.json ] && [ -f .docker/storage-seeds/gradients.json ]; then
+    cp .docker/storage-seeds/gradients.json storage/gradients.json
+  fi
+
   # Ensure .env exists
   if [ ! -f .env ]; then
     cp .env.example .env


### PR DESCRIPTION
## Summary
- add a seeded gradients.json so the application has fallback gradient data
- copy the seed into storage during container bootstrap when the storage volume is empty

## Testing
- not run (infrastructure change only)


------
https://chatgpt.com/codex/tasks/task_e_68ec002450a4832ea1f8d3494bab1328