### PR TITLE
Add CSS gradient helper for background images

### DIFF
--- a/patches/ColorUtils.php
+++ b/patches/ColorUtils.php
@@ -39,6 +39,22 @@ class ColorUtils
     }
 
     /**
+     * Build a CSS-ready linear gradient definition from a random palette.
+     */
+    public static function randomBackgroundImage(): string
+    {
+        $colors = self::randomGradient();
+
+        if (empty($colors)) {
+            return '';
+        }
+
+        $stops = implode(', ', $colors);
+
+        return sprintf('linear-gradient(135deg, %s)', $stops);
+    }
+
+    /**
      * Attempt to download gradients from the upstream source.
      *
      * @return array<int, array<int, string>>


### PR DESCRIPTION
## Summary
- add a ColorUtils::randomBackgroundImage helper that composes a CSS linear gradient
- ensure the helper falls back cleanly when no colors are available

## Testing
- php -l patches/ColorUtils.php

------
https://chatgpt.com/codex/tasks/task_e_68ec066e370c832ebca71abaa06bb3fc