### PR TITLE
Ensure backgrounds.json is created during bootstrap

### DIFF
--- a/.docker/storage-seeds/backgrounds.json
+++ b/.docker/storage-seeds/backgrounds.json
@@ -1,0 +1,32 @@
+[
+  {
+    "label": "Sunset Glow",
+    "value": "linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%)",
+    "colors": ["#ff9a9e", "#fad0c4"]
+  },
+  {
+    "label": "Ocean Breeze",
+    "value": "linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)",
+    "colors": ["#4facfe", "#00f2fe"]
+  },
+  {
+    "label": "Emerald Mist",
+    "value": "linear-gradient(135deg, #84fab0 0%, #8fd3f4 100%)",
+    "colors": ["#84fab0", "#8fd3f4"]
+  },
+  {
+    "label": "Violet Dream",
+    "value": "linear-gradient(135deg, #a18cd1 0%, #fbc2eb 100%)",
+    "colors": ["#a18cd1", "#fbc2eb"]
+  },
+  {
+    "label": "Golden Hour",
+    "value": "linear-gradient(135deg, #f6d365 0%, #fda085 100%)",
+    "colors": ["#f6d365", "#fda085"]
+  },
+  {
+    "label": "Aurora",
+    "value": "linear-gradient(135deg, #30cfd0 0%, #330867 100%)",
+    "colors": ["#30cfd0", "#330867"]
+  }
+]

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -23,6 +23,14 @@ bootstrap_app() {
     cp .docker/storage-seeds/headers.json storage/headers.json
   fi
 
+  if [ ! -f storage/backgrounds.json ]; then
+    if [ -f .docker/storage-seeds/backgrounds.json ]; then
+      cp .docker/storage-seeds/backgrounds.json storage/backgrounds.json
+    else
+      printf '[]' > storage/backgrounds.json
+    fi
+  fi
+
   # Ensure .env exists
   if [ ! -f .env ]; then
     cp .env.example .env


### PR DESCRIPTION
## Summary
- add a default backgrounds.json seed so role creation no longer fails when the file is missing
- teach the bootstrap helper to always provision storage/backgrounds.json, falling back to an empty array when no seed is bundled

## Testing
- bash -n scripts/bootstrap.sh

------
https://chatgpt.com/codex/tasks/task_e_68ec0c779cd8832ebc05a2aad12a7cdc