### PR TITLE
Improve resilience of view defaults and gradient loading

### DIFF
--- a/patches/AppServiceProvider.php
+++ b/patches/AppServiceProvider.php
@@ -25,11 +25,24 @@ class AppServiceProvider extends ServiceProvider
     {
         Schema::defaultStringLength(191);
 
-        // Allow Docker image patch script to gate HTTPS forcing behind env var.
-        URL::forceScheme('https');
+        $forceHttps = config('app.force_https');
+
+        if ($forceHttps === null) {
+            $forceHttps = (bool) env('FORCE_HTTPS', false);
+        }
+
+        if ($forceHttps) {
+            URL::forceScheme('https');
+        }
 
         if ($this->app->runningInConsole()) {
             return;
+        }
+
+        foreach (['schedules', 'venues', 'curators'] as $key) {
+            if (!View::shared($key)) {
+                View::share($key, collect());
+            }
         }
 
         View::composer('*', function (ViewView $view): void {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,12 +15,20 @@ bootstrap_app() {
     bootstrap/cache \
     database
 
-  if [ ! -f storage/gradients.json ] && [ -f .docker/storage-seeds/gradients.json ]; then
-    cp .docker/storage-seeds/gradients.json storage/gradients.json
+  if [ ! -f storage/gradients.json ]; then
+    if [ -f .docker/storage-seeds/gradients.json ]; then
+      cp .docker/storage-seeds/gradients.json storage/gradients.json
+    else
+      printf '[]' > storage/gradients.json
+    fi
   fi
 
-  if [ ! -f storage/headers.json ] && [ -f .docker/storage-seeds/headers.json ]; then
-    cp .docker/storage-seeds/headers.json storage/headers.json
+  if [ ! -f storage/headers.json ]; then
+    if [ -f .docker/storage-seeds/headers.json ]; then
+      cp .docker/storage-seeds/headers.json storage/headers.json
+    else
+      printf '[]' > storage/headers.json
+    fi
   fi
 
   if [ ! -f storage/backgrounds.json ]; then


### PR DESCRIPTION
## Summary
- gate HTTPS forcing behind configuration while seeding default view data for key templates
- load gradients from local storage with safe fallbacks before reaching for remote palettes
- always create placeholder JSON assets during bootstrap to avoid missing-file errors

## Testing
- not run (infrastructure-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ec5b9f04d8832eb80b4cb5fdc640c4