### PR TITLE
Guard home view variables in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,11 @@ COPY scripts/fix_role_controller_names.php /tmp/fix_role_controller_names.php
 RUN php /tmp/fix_role_controller_names.php /var/www/html \
  && rm /tmp/fix_role_controller_names.php
 
+# Guard home view templates against missing data
+COPY scripts/normalize_home_view.php /tmp/normalize_home_view.php
+RUN php /tmp/normalize_home_view.php /var/www/html \
+ && rm /tmp/normalize_home_view.php
+
 # Gate any forceScheme('https') behind FORCE_HTTPS
 COPY scripts/force_https_patch.php /tmp/force_https_patch.php
 RUN php /tmp/force_https_patch.php /var/www/html \

--- a/scripts/normalize_home_view.php
+++ b/scripts/normalize_home_view.php
@@ -1,0 +1,60 @@
+<?php
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "This script must be run from the command line.\n");
+    exit(1);
+}
+
+$root = $argv[1] ?? getcwd();
+$path = rtrim($root, DIRECTORY_SEPARATOR) . '/resources/views/home.blade.php';
+
+if (!is_file($path)) {
+    exit(0);
+}
+
+$contents = file_get_contents($path);
+
+if ($contents === false) {
+    fwrite(STDERR, "Failed to read home.blade.php\n");
+    exit(1);
+}
+
+$marker = 'HOME_VIEW_VARIABLE_GUARD';
+
+if (strpos($contents, $marker) !== false) {
+    exit(0);
+}
+
+$normalizer = <<<'BLADE'
+{{-- HOME_VIEW_VARIABLE_GUARD --}}
+@php
+    $schedules = $schedules ?? [];
+    if (!$schedules instanceof \Illuminate\Support\Collection) {
+        $schedules = collect($schedules);
+    }
+
+    $venues = $venues ?? [];
+    if (!$venues instanceof \Illuminate\Support\Collection) {
+        $venues = collect($venues);
+    }
+
+    $curators = $curators ?? [];
+    if (!$curators instanceof \Illuminate\Support\Collection) {
+        $curators = collect($curators);
+    }
+@endphp
+
+BLADE;
+
+$normalizer = str_replace("\n", PHP_EOL, $normalizer);
+
+if (preg_match('/^\s*@extends[^\n]*\n/i', $contents, $match)) {
+    $insertPos = strlen($match[0]);
+    $contents = substr($contents, 0, $insertPos) . PHP_EOL . $normalizer . substr($contents, $insertPos);
+} else {
+    $contents = $normalizer . $contents;
+}
+
+if (file_put_contents($path, $contents) === false) {
+    fwrite(STDERR, "Failed to write home.blade.php\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- add a build-time script that populates default collections for optional home view datasets
- wire the new script into the Docker image so missing schedule data no longer breaks rendering

## Testing
- php -l scripts/normalize_home_view.php

------
https://chatgpt.com/codex/tasks/task_e_68ec5dfa8394832e9f696357b63d0613