### PR TITLE
Gracefully handle RoleController regex failures

### DIFF
--- a/scripts/fix_role_controller_names.php
+++ b/scripts/fix_role_controller_names.php
@@ -61,8 +61,8 @@ function applyPattern(
         restore_error_handler();
 
         if ($hadError || $result === null) {
-            fwrite(STDERR, "Failed to process RoleController.php\n");
-            exit(1);
+            fwrite(STDERR, "Warning: unable to rewrite RoleController.php with pattern {$pattern}. Skipping.\n");
+            return $original;
         }
     }
 
@@ -102,8 +102,9 @@ function matchAll(
         restore_error_handler();
 
         if ($hadError || $count === false) {
-            fwrite(STDERR, "Failed to process RoleController.php\n");
-            exit(1);
+            fwrite(STDERR, "Warning: unable to scan RoleController.php with pattern {$pattern}. Skipping.\n");
+            $matches = [];
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent the RoleController name-normalisation helper script from aborting when both regex patterns fail to compile
- fall back to leaving the controller untouched while emitting a warning so the container build can proceed

## Testing
- php -l scripts/fix_role_controller_names.php

------
https://chatgpt.com/codex/tasks/task_e_68ec67e5753c832eadfaae5fa858804a