### PR TITLE
Initialize match list before scanning assignments

### DIFF
--- a/scripts/fix_role_controller_names.php
+++ b/scripts/fix_role_controller_names.php
@@ -182,6 +182,8 @@ $code = applyPattern($optionalPattern, $optionalFallback, function (array $match
 $assignmentPattern = '/(?<target>\$[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*(?:\s*(?:->\s*[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*|\[[^\]]+\]))*)\s*=\s*' . $jsonDecodePattern . $recursiveCallPattern . '\s*;/i';
 $assignmentFallback = '/(?<target>\$[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*(?:\s*(?:->\s*[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*|\[[^\]]+\]))*)\s*=\s*' . $jsonDecodePattern . $fallbackCallPattern . '\s*;/i';
 
+$assignmentMatches = [];
+
 if (matchAll($assignmentPattern, $assignmentFallback, $code, PREG_SET_ORDER, $assignmentMatches)) {
     $expressions = [];
 


### PR DESCRIPTION
## Summary
- initialize the assignment match array before scanning RoleController assignments to avoid null references

## Testing
- php scripts/fix_role_controller_names.php .

------
https://chatgpt.com/codex/tasks/task_e_68ec68c29c38832eb25e65409246c345