### PR TITLE
Handle chained property access when normalizing RoleController names

### DIFF
--- a/scripts/fix_role_controller_names.php
+++ b/scripts/fix_role_controller_names.php
@@ -197,8 +197,9 @@ if (matchAll($assignmentPattern, $assignmentFallback, $code, PREG_SET_ORDER, $as
 
     foreach (array_keys($expressions) as $expression) {
         $expressionPattern = buildExpressionPattern($expression);
-        $variablePattern = '/(' . $expressionPattern . ')\s*(\?->|->)\s*name/i';
-        $optionalVariablePattern = '/optional\s*\(\s*(' . $expressionPattern . ')\s*\)\s*(\?->|->)\s*name/i';
+        $accessChainPattern = '(?:\s*(?:->\s*[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*|\[[^\]]+\]))*';
+        $variablePattern = '/(' . $expressionPattern . $accessChainPattern . ')\s*(\?->|->)\s*name/i';
+        $optionalVariablePattern = '/optional\s*\(\s*(' . $expressionPattern . $accessChainPattern . ')\s*\)\s*(\?->|->)\s*name/i';
 
         $replacements = [];
 


### PR DESCRIPTION
## Summary
- expand the RoleController name normalizer to match chained property access before reaching the name key
- ensure optional() wrappers that include nested property access also defer to resolveLocalizedName

## Testing
- php -l scripts/fix_role_controller_names.php

------
https://chatgpt.com/codex/tasks/task_e_68ec6afa949c832eb694dab52354e128