### PR TITLE
Enable manual Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,13 +49,27 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and (optionally) publish image
+      - name: Build image (no push)
+        if: env.SHOULD_PUSH != 'true'
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           target: single
-          push: ${{ env.SHOULD_PUSH == 'true' }}
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and publish image
+        if: env.SHOULD_PUSH == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          target: single
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,17 +5,24 @@ on:
     types: [closed]
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push image to Docker Hub"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
 
 env:
   REGISTRY_IMAGE: ${{ secrets.DOCKERHUB_REPOSITORY != '' && secrets.DOCKERHUB_REPOSITORY || format('ghcr.io/{0}', github.repository) }}
-  SHOULD_PUSH: ${{ github.event.pull_request.merged == true && secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' && secrets.DOCKERHUB_REPOSITORY != '' }}
+  SHOULD_PUSH: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.merged == true) || (github.event_name == 'workflow_dispatch' && inputs.push != 'false')) && secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' && secrets.DOCKERHUB_REPOSITORY != '' }}
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- allow the docker publish workflow to be triggered manually via workflow_dispatch
- gate docker hub pushes behind an optional workflow input while retaining the existing pull request behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee65995900832ea65306ed70de21e0