### PR TITLE
Ensure nginx can read public storage files

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -136,5 +136,10 @@ bootstrap_app() {
   php artisan storage:link || true
 
   chown -R www-data:www-data storage bootstrap/cache database || true
+  chmod -R ug+rwX storage bootstrap/cache database || true
+
+  if [ -d storage/app/public ]; then
+    chmod -R a+rX storage/app/public || true
+  fi
   cd "$orig_dir"
 }


### PR DESCRIPTION
## Summary
- ensure the bootstrap script grants shared storage directories read/execute permissions for nginx
- keep storage and cache directories group-writable while preserving access for the php-fpm user

## Testing
- sh -n scripts/bootstrap.sh

------
https://chatgpt.com/codex/tasks/task_e_68f7e25802e0832ea8e7b752f18b5b24