### PR TITLE
Add arm64 build support to Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,8 @@ permissions:
 env:
   REGISTRY_IMAGE: ${{ secrets.DOCKERHUB_REPOSITORY != '' && secrets.DOCKERHUB_REPOSITORY || format('ghcr.io/{0}', github.repository) }}
   SHOULD_PUSH: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.merged == true) || (github.event_name == 'workflow_dispatch' && inputs.push != 'false')) && secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' && secrets.DOCKERHUB_REPOSITORY != '' }}
+  PUSH_PLATFORMS: linux/amd64,linux/arm64
+  TEST_PLATFORM: linux/amd64
 
 jobs:
   build:
@@ -27,6 +29,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -56,7 +61,9 @@ jobs:
           context: .
           file: ./Dockerfile
           target: single
+          platforms: ${{ env.TEST_PLATFORM }}
           push: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -69,6 +76,7 @@ jobs:
           context: .
           file: ./Dockerfile
           target: single
+          platforms: ${{ env.PUSH_PLATFORMS }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- update the Docker publish workflow to build and push both amd64 and arm64 images
- configure QEMU emulation so the GitHub Action can cross-compile the image

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa234ccec4832eb509b3c953961c12